### PR TITLE
Add GitHub Skills activity to activities list

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,6 +75,13 @@ activities = {
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
+        ,
+        "GitHub Skills": {
+            "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program.",
+            "schedule": "Special event, registration closes this week",
+            "max_participants": 25,
+            "participants": []
+        }
 }
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -74,8 +74,7 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-        ,
+    },
         "GitHub Skills": {
             "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program.",
             "schedule": "Special event, registration closes this week",


### PR DESCRIPTION
Přidána nová aktivita "GitHub Skills" dle požadavku issue #6. Studenti se nyní mohou registrovat na tuto speciální akci, která je součástí GitHub Certifications programu.